### PR TITLE
add fn_ prefix to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ class SomeService
 {
     // ...
 
-    #[AsTwigFunction] // will be available as "someMethod" in twig
+    #[AsTwigFunction] // will be available as "fn_someMethod" in twig
     public function someMethod($arg1, $arg2): string
     {
         // ...
     }
 
-    #[AsTwigFunction('alias')] // will be available as "alias" in twig
+    #[AsTwigFunction('alias')] // will be available as "fn_alias" in twig
     public function anotherMethod($arg1, $arg2): string
     {
         // ...

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class SomeService
         // ...
     }
 
-    #[AsTwigFunction('alias')] // will be available as "fn_alias" in twig
+    #[AsTwigFunction('alias')] // will be available as "fn_alias()" in twig
     public function anotherMethod($arg1, $arg2): string
     {
         // ...

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class SomeService
 {
     // ...
 
-    #[AsTwigFunction] // will be available as "fn_someMethod" in twig
+    #[AsTwigFunction] // will be available as "fn_someMethod()" in twig
     public function someMethod($arg1, $arg2): string
     {
         // ...


### PR DESCRIPTION
I think the functions become available with an fn_ prefix.  I'll submit an issue to make that optional, as I'd prefer calling the function without fn_